### PR TITLE
Make remote write tenant header configurable

### DIFF
--- a/cmd/avalanche.go
+++ b/cmd/avalanche.go
@@ -48,6 +48,7 @@ var (
 	remoteReqsInterval  = kingpin.Flag("remote-write-interval", "delay between each remote write request.").Default("100ms").Duration()
 	remoteTenant        = kingpin.Flag("remote-tenant", "Tenant ID to include in remote_write send").Default("0").String()
 	tlsClientInsecure   = kingpin.Flag("tls-client-insecure", "Skip certificate check on tls connection").Default("false").Bool()
+	remoteTenantHeader  = kingpin.Flag("remote-tenant-header", "Tenant ID to include in remote_write send. The default, is the default tenant header expected by Cortex.").Default("X-Scope-OrgID").String()
 )
 
 func main() {
@@ -81,6 +82,7 @@ func main() {
 			TLSClientConfig: tls.Config{
 				InsecureSkipVerify: *tlsClientInsecure,
 			},
+			TenantHeader:    *remoteTenantHeader,
 		}
 
 		// Collect Pprof during the write only if not collecting within a regular interval.

--- a/cmd/avalanche.go
+++ b/cmd/avalanche.go
@@ -82,7 +82,7 @@ func main() {
 			TLSClientConfig: tls.Config{
 				InsecureSkipVerify: *tlsClientInsecure,
 			},
-			TenantHeader:    *remoteTenantHeader,
+			TenantHeader: *remoteTenantHeader,
 		}
 
 		// Collect Pprof during the write only if not collecting within a regular interval.

--- a/metrics/serve.go
+++ b/metrics/serve.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nelkinda/health-go"
+	health "github.com/nelkinda/health-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -53,6 +53,7 @@ type ConfigWrite struct {
 	PprofURLs       []*url.URL
 	Tenant          string
 	TLSClientConfig tls.Config
+	TenantHeader    string
 }
 
 // Client for the remote write requests.
@@ -68,7 +69,7 @@ func SendRemoteWrite(config *ConfigWrite) error {
 	var rt http.RoundTripper = &http.Transport{
 		TLSClientConfig: &config.TLSClientConfig,
 	}
-	rt = &cortexTenantRoundTripper{tenant: config.Tenant, rt: rt}
+	rt = &cortexTenantRoundTripper{tenant: config.Tenant, tenantHeader: config.TenantHeader, rt: rt}
 	httpClient := &http.Client{Transport: rt}
 
 	c := Client{
@@ -79,16 +80,17 @@ func SendRemoteWrite(config *ConfigWrite) error {
 	return c.write()
 }
 
-// Add the tenant ID header required by Cortex
-func (rt *cortexTenantRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+// Add the tenant ID header
+func (rt *tenantRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = cloneRequest(req)
-	req.Header.Set("X-Scope-OrgID", rt.tenant)
+	req.Header.Set(rt.tenantHeader, rt.tenant)
 	return rt.rt.RoundTrip(req)
 }
 
-type cortexTenantRoundTripper struct {
-	tenant string
-	rt     http.RoundTripper
+type tenantRoundTripper struct {
+	tenant       string
+	tenantHeader string
+	rt           http.RoundTripper
 }
 
 // cloneRequest returns a clone of the provided *http.Request.

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -69,7 +69,7 @@ func SendRemoteWrite(config *ConfigWrite) error {
 	var rt http.RoundTripper = &http.Transport{
 		TLSClientConfig: &config.TLSClientConfig,
 	}
-	rt = &cortexTenantRoundTripper{tenant: config.Tenant, tenantHeader: config.TenantHeader, rt: rt}
+	rt = &tenantRoundTripper{tenant: config.Tenant, tenantHeader: config.TenantHeader, rt: rt}
 	httpClient := &http.Client{Transport: rt}
 
 	c := Client{


### PR DESCRIPTION
This PR makes the tenant header set in the remote write roundtripper configurable. 

In Thanos, `THANOS-TENANT` is the default tenant header. This change makes  `avalanche` compatible with other metrics backends.

The default `remote-tenant-header` is kept as the Cortext default so this PR does not break any existing users. 

Signed-off-by: Ian Billett <ibillett@redhat.com>