### PR TITLE
Update README with docker pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ avalanche --help
 ## run Docker image
 
 ```bash
+docker pull quay.io/prometheuscommunity/avalanche:main
 docker run quay.io/prometheuscommunity/avalanche --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ avalanche --help
 ## run Docker image
 
 ```bash
-docker pull quay.io/prometheuscommunity/avalanche:main
-docker run quay.io/prometheuscommunity/avalanche --help
+docker run quay.io/prometheuscommunity/avalanche:main --help
 ```
 
 ## Endpoints


### PR DESCRIPTION
The `docker run quay.io/prometheuscommunity/avalanche --help` assumes the container already exists on the host system. Since the default tag is `main` and not `latest` the `run` command doesn't work unless you pull the image first.