### PR TITLE
[doc] Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ Two endpoints are available :
 ## build and run go binary
 
 ```bash
-go get github.com/prometheus-community/avalanche/cmd/...
-avalanche --help
+go install github.com/prometheus-community/avalanche/cmd@latest
+go/bin/cmd --help
 ```


### PR DESCRIPTION
`go get` is deprecated - update README to use `go install`.