### PR TITLE
feat: Add option to run indefinitely; fix races

### DIFF
--- a/cmd/avalanche.go
+++ b/cmd/avalanche.go
@@ -69,7 +69,7 @@ func main() {
 	remotePprofURLs := kingpin.Flag("remote-pprof-urls", "a list of urls to download pprofs during the remote write: --remote-pprof-urls=http://127.0.0.1:10902/debug/pprof/heap --remote-pprof-urls=http://127.0.0.1:10902/debug/pprof/profile").URLList()
 	remotePprofInterval := kingpin.Flag("remote-pprof-interval", "how often to download pprof profiles. When not provided it will download a profile once before the end of the test.").Duration()
 	remoteBatchSize := kingpin.Flag("remote-batch-size", "how many samples to send with each remote_write API request.").Default("2000").Int()
-	remoteRequestCount := kingpin.Flag("remote-requests-count", "how many requests to send in total to the remote_write API.").Default("100").Int()
+	remoteRequestCount := kingpin.Flag("remote-requests-count", "How many requests to send in total to the remote_write API. Set to -1 to run indefinitely.").Default("100").Int()
 	remoteReqsInterval := kingpin.Flag("remote-write-interval", "delay between each remote write request.").Default("100ms").Duration()
 	remoteTenant := kingpin.Flag("remote-tenant", "Tenant ID to include in remote_write send").Default("0").String()
 	tlsClientInsecure := kingpin.Flag("tls-client-insecure", "Skip certificate check on tls connection").Default("false").Bool()

--- a/metrics/serve.go
+++ b/metrics/serve.go
@@ -517,6 +517,12 @@ func (c *Collector) Run() error {
 	go c.handleSeriesTicks(&mutableState.seriesCycle, unsafeReadOnlyGetState)
 	go c.handleMetricTicks(&mutableState.metricCycle, unsafeReadOnlyGetState)
 
+	// Mark best-effort update, so remote write knows (if enabled).
+	select {
+	case c.updateNotifyCh <- struct{}{}:
+	default:
+	}
+
 	<-c.stopCh
 	return nil
 }

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -137,7 +137,7 @@ func (c *Client) write(ctx context.Context) error {
 
 		// Download the pprofs during half of the iteration to get avarege readings.
 		// Do that only when it is not set to take profiles at a given interval.
-		if len(c.config.PprofURLs) > 0 && c.config.RequestCount != -1 && ii == c.config.RequestCount/2 {
+		if len(c.config.PprofURLs) > 0 && c.config.RequestCount != -1 && left == c.config.RequestCount/2 {
 			wgPprof.Add(1)
 			go func() {
 				download.URLs(c.config.PprofURLs, time.Now().Format("2-Jan-2006-15:04:05"))

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -128,14 +128,14 @@ func (c *Client) write(ctx context.Context) error {
 	log.Printf("Sending: %v timeseries, %v samples, %v timeseries per request, %v delay between requests\n", len(tss), c.config.RequestCount, c.config.BatchSize, c.config.RequestInterval)
 	ticker := time.NewTicker(c.config.RequestInterval)
 	defer ticker.Stop()
-	for ii := 0; ii < c.config.RequestCount; ii++ {
+	for ii := 0; c.config.RequestCount == -1 || ii < c.config.RequestCount; ii++ {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
 		// Download the pprofs during half of the iteration to get avarege readings.
 		// Do that only when it is not set to take profiles at a given interval.
-		if len(c.config.PprofURLs) > 0 && ii == c.config.RequestCount/2 {
+		if len(c.config.PprofURLs) > 0 && c.config.RequestCount != -1 && ii == c.config.RequestCount/2 {
 			wgPprof.Add(1)
 			go func() {
 				download.URLs(c.config.PprofURLs, time.Now().Format("2-Jan-2006-15:04:05"))

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -130,7 +130,7 @@ func (c *Client) write(ctx context.Context) error {
 	defer ticker.Stop()
 	left := c.config.RequestCount // left equal to -1 means infinite amount of requests.
 	for left != 0 {
-	      left--
+		left--
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -128,7 +128,9 @@ func (c *Client) write(ctx context.Context) error {
 	log.Printf("Sending: %v timeseries, %v samples, %v timeseries per request, %v delay between requests\n", len(tss), c.config.RequestCount, c.config.BatchSize, c.config.RequestInterval)
 	ticker := time.NewTicker(c.config.RequestInterval)
 	defer ticker.Stop()
-	for ii := 0; c.config.RequestCount == -1 || ii < c.config.RequestCount; ii++ {
+	left := c.config.RequestCount // left equal to -1 means infinite amount of requests.
+	for left != 0 {
+	      left--
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}


### PR DESCRIPTION
cc @jmichalek132 

This is on top of your https://github.com/prometheus-community/avalanche/pull/89 as mentioned offline

Tested manually:
* ` go run cmd/avalanche.go --remote-url=http://remote.com --remote-tenant=redacted --remote-requests-count=-1 --remote-tenant-header=redacted --gauge-metric-count=200`
* ` go run cmd/avalanche.go --remote-url=http://remote.com --remote-tenant=redacted --remote-requests-count=20 --remote-tenant-header=redacted --gauge-metric-count=200`