### PR TITLE
Change default for `--metric-interval` to 0 (breaking change)

### DIFF
--- a/metrics/serve.go
+++ b/metrics/serve.go
@@ -136,7 +136,7 @@ func NewConfigFromFlags(flagReg func(name, help string) *kingpin.FlagClause) *Co
 		IntVar(&cfg.ValueInterval)
 	flagReg("series-interval", "Change series_id label values every {interval} seconds. 0 means no change.").Default("60").
 		IntVar(&cfg.SeriesInterval)
-	flagReg("metric-interval", "Change __name__ label values every {interval} seconds. 0 means no change.").Default("120").
+	flagReg("metric-interval", "Change __name__ label values every {interval} seconds. 0 means no change.").Default("0").
 		IntVar(&cfg.MetricInterval)
 	flagReg("series-change-interval", "Change the number of series every {interval} seconds. Applies to 'gradual-change', 'double-halve' and 'spike' modes. 0 means no change.").Default("30").
 		IntVar(&cfg.SeriesChangeInterval)


### PR DESCRIPTION
See related discussion: https://github.com/prometheus-community/avalanche/pull/97#discussion_r1792963626

> I think we should move this default to zero. Essentially I don't see real case of changing metric names in any application. Metric names are generally stable AFAIK, do you know any cases where that's not true? Are they often?


cc @jmichalek132