### PR TITLE
Log remote write errors as they happen

### DIFF
--- a/metrics/write.go
+++ b/metrics/write.go
@@ -341,9 +341,8 @@ func (c *Client) Store(ctx context.Context, req *prompb.WriteRequest) error {
 			line = scanner.Text()
 		}
 		err = fmt.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
+		log.Println(err)
 	}
-	if httpResp.StatusCode/100 == 5 {
-		return err
-	}
+
 	return err
 }


### PR DESCRIPTION
This commit allows logging remote write errors as they happen instead of waiting till the end of 20*refreshInterval. The motivation is to allow catching config issues early during ad-hoc benchmarking.

Addresses #81 