### PR TITLE
Add testcase to check for missing labels from the generated metrics 

### DIFF
--- a/metrics/serve.go
+++ b/metrics/serve.go
@@ -505,6 +505,7 @@ func (c *Collector) Run() error {
 		labelValues = append(labelValues, split[1])
 	}
 
+	c.labelKeys = labelKeys
 	mutableState := &metricState{seriesCount: c.cfg.SeriesCount, labelValues: labelValues}
 	// unsafe means you need to lock c.mu to use it.
 	unsafeReadOnlyGetState := func() metricState { return *mutableState }

--- a/metrics/serve.go
+++ b/metrics/serve.go
@@ -505,7 +505,6 @@ func (c *Collector) Run() error {
 		labelValues = append(labelValues, split[1])
 	}
 
-	c.labelKeys = labelKeys
 	mutableState := &metricState{seriesCount: c.cfg.SeriesCount, labelValues: labelValues}
 	// unsafe means you need to lock c.mu to use it.
 	unsafeReadOnlyGetState := func() metricState { return *mutableState }

--- a/metrics/serve_test.go
+++ b/metrics/serve_test.go
@@ -441,7 +441,7 @@ func TestCollectorLabels(t *testing.T) {
 	})
 
 	select {
-	case <- col.updateNotifyCh:
+	case <-col.updateNotifyCh:
 		metricsFamilies, err := reg.Gather()
 		assert.NotEmpty(t, metricsFamilies)
 		assert.NoError(t, err)
@@ -460,7 +460,7 @@ func TestCollectorLabels(t *testing.T) {
 				assert.Contains(t, labelMap, "cycle_id")
 			}
 		}
-	case <- time.After(2 * time.Second):
-		t.Fail();
+	case <-time.After(2 * time.Second):
+		t.Fail()
 	}
 }


### PR DESCRIPTION
We have been using avalanche to test out remote write capability in our distributed metrics architecture, we noticed that avalanche wasn't adding any labels let alone the `--const-labels` to the metrics. The solution in the PR should hopefully fix it.
Following are the changes in the PR

- Added a test to check for labels in the generated metrics
- Updated line 516-517 in metrics/serve.go to fix the issue

