### PR TITLE
Sets the default value of remote-out-of-order to false

### DIFF
--- a/metrics/write.go
+++ b/metrics/write.go
@@ -76,7 +76,7 @@ func NewWriteConfigFromFlags(flagReg func(name, help string) *kingpin.FlagClause
 	flagReg("remote-tenant-header", "Tenant ID to include in remote_write send. The default, is the default tenant header expected by Cortex.").Default("X-Scope-OrgID").
 		StringVar(&cfg.TenantHeader)
 	// TODO(bwplotka): Make this a non-bool flag (e.g. out-of-order-min-time).
-	flagReg("remote-out-of-order", "Enable out-of-order timestamps in remote write requests").Default("true").
+	flagReg("remote-out-of-order", "Enable out-of-order timestamps in remote write requests").Default("false").
 		BoolVar(&cfg.OutOfOrder)
 
 	return cfg


### PR DESCRIPTION
As part of testing our metrics stack, avalanche has been really helpful but unfortunately we can't disable remote-out-of-order (required for some of our tests). We have tried setting the flag to `false` but kingpin is not able to parse. Would it be possible to set the default as `false` and then it could be enabled by passing the command line flag? 

Would be really helpful if we can do this, please let us know your thoughts. 