### PR TITLE
Fix mtypes zero divide when the input has no summary metrics or no histogram metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ./avalanche
 .build/
 .idea/
-mtypes
-avalanche
+/mtypes
+/avalanche
+/cmd/mtypes/mtypes
+/cmd/avalanche/avalanche

--- a/cmd/mtypes/main.go
+++ b/cmd/mtypes/main.go
@@ -73,70 +73,84 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	total := computeTotal(statistics)
+	writeStatistics(os.Stdout, total, statistics)
+	if *avalancheFlagsForTotal > 0 {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(os.Stdout, "Avalanche flags for the similar distribution to get to the adjusted series goal of:", *avalancheFlagsForTotal)
+		flags, adjustedSum := computeAvalancheFlags(*avalancheFlagsForTotal, total, statistics)
+		for _, f := range flags {
+			fmt.Fprintln(os.Stdout, f)
+		}
+		fmt.Fprintln(os.Stdout, "This should give the total adjusted series to:", adjustedSum*10)
+	}
+}
+
+func computeTotal(statistics map[dto.MetricType]stats) stats {
 	var total stats
 	for _, s := range statistics {
 		total.families += s.families
 		total.series += s.series
 		total.adjustedSeries += s.adjustedSeries
 	}
+	return total
+}
 
-	writeStatistics(os.Stdout, total, statistics)
+func computeAvalancheFlags(avalancheFlagsForTotal int, total stats, statistics map[dto.MetricType]stats) ([]string, int) {
+	// adjustedGoal is tracking the # of adjusted series we want to generate with avalanche.
+	adjustedGoal := float64(avalancheFlagsForTotal)
+	adjustedGoal /= 10.0 // Assuming --series-count=10
+	// adjustedSum is tracking the total sum of series so far (at the end hopefully adjustedSum ~= adjustedGoal)
+	adjustedSum := 0
+	// Accumulate flags
+	var flags []string
+	for _, mtype := range allTypes {
+		s := statistics[mtype]
 
-	if *avalancheFlagsForTotal > 0 {
-		// adjustedGoal is tracking the # of adjusted series we want to generate with avalanche.
-		adjustedGoal := float64(*avalancheFlagsForTotal)
-		fmt.Println()
-		fmt.Println("Avalanche flags for the similar distribution to get to the adjusted series goal of:", adjustedGoal)
+		// adjustedSeriesRatio is tracking the ratio of this type in the input file.
+		// We try to get similar ratio, but with different absolute counts, given the total sum of series we are aiming for.
+		adjustedSeriesRatio := float64(s.adjustedSeries) / float64(total.adjustedSeries)
 
-		adjustedGoal /= 10.0 // Assuming --series-count=10
-		// adjustedSum is tracking the total sum of series so far (at the end hopefully adjustedSum ~= adjustedGoal)
-		adjustedSum := 0
-		for _, mtype := range allTypes {
-			s := statistics[mtype]
+		// adjustedSeriesForType is tracking (per metric type), how many unique series of that
+		// metric type avalanche needs to create according to the ratio we got from our input.
+		adjustedSeriesForType := int(adjustedGoal * adjustedSeriesRatio)
 
-			// adjustedSeriesRatio is tracking the ratio of this type in the input file.
-			// We try to get similar ratio, but with different absolute counts, given the total sum of series we are aiming for.
-			adjustedSeriesRatio := float64(s.adjustedSeries) / float64(total.adjustedSeries)
-
-			// adjustedSeriesForType is tracking (per metric type), how many unique series of that
-			// metric type avalanche needs to create according to the ratio we got from our input.
-			adjustedSeriesForType := int(adjustedGoal * adjustedSeriesRatio)
-
-			switch mtype {
-			case dto.MetricType_GAUGE:
-				fmt.Printf("--gauge-metric-count=%v\n", adjustedSeriesForType)
-				adjustedSum += adjustedSeriesForType
-			case dto.MetricType_COUNTER:
-				fmt.Printf("--counter-metric-count=%v\n", adjustedSeriesForType)
-				adjustedSum += adjustedSeriesForType
-			case dto.MetricType_HISTOGRAM:
-				avgBkts := s.buckets / s.series
-				adjustedSeriesForType /= 2 + avgBkts
-				fmt.Printf("--histogram-metric-count=%v\n", adjustedSeriesForType)
-				fmt.Printf("--histogram-metric-bucket-count=%v\n", avgBkts-1) // -1 is due to caveat of additional +Inf not added by avalanche.
-				adjustedSum += adjustedSeriesForType * (2 + avgBkts)
-			case metricType_NATIVE_HISTOGRAM:
-				fmt.Printf("--native-histogram-metric-count=%v\n", adjustedSeriesForType)
-				adjustedSum += adjustedSeriesForType
-			case dto.MetricType_SUMMARY:
-				avgObjs := s.objectives / s.series
-				adjustedSeriesForType /= 2 + avgObjs
-				fmt.Printf("--summary-metric-count=%v\n", adjustedSeriesForType)
-				fmt.Printf("--summary-metric-objective-count=%v\n", avgObjs)
-				adjustedSum += adjustedSeriesForType * (2 + avgObjs)
-			default:
-				if s.series > 0 {
-					log.Fatalf("not supported %v metric in avalanche", mtype)
-				}
+		switch mtype {
+		case dto.MetricType_GAUGE:
+			flags = append(flags, fmt.Sprintf("--gauge-metric-count=%v", adjustedSeriesForType))
+			adjustedSum += adjustedSeriesForType
+		case dto.MetricType_COUNTER:
+			flags = append(flags, fmt.Sprintf("--counter-metric-count=%v", adjustedSeriesForType))
+			adjustedSum += adjustedSeriesForType
+		case dto.MetricType_HISTOGRAM:
+			avgBkts := s.buckets / s.series
+			adjustedSeriesForType /= 2 + avgBkts
+			flags = append(flags, fmt.Sprintf("--histogram-metric-count=%v", adjustedSeriesForType))
+			flags = append(flags, fmt.Sprintf("--histogram-metric-bucket-count=%v", avgBkts-1)) // -1 is due to caveat of additional +Inf not added by avalanche.
+			adjustedSum += adjustedSeriesForType * (2 + avgBkts)
+		case metricType_NATIVE_HISTOGRAM:
+			flags = append(flags, fmt.Sprintf("--native-histogram-metric-count=%v", adjustedSeriesForType))
+			adjustedSum += adjustedSeriesForType
+		case dto.MetricType_SUMMARY:
+			avgObjs := s.objectives / s.series
+			adjustedSeriesForType /= 2 + avgObjs
+			flags = append(flags, fmt.Sprintf("--summary-metric-count=%v", adjustedSeriesForType))
+			flags = append(flags, fmt.Sprintf("--summary-metric-objective-count=%v", avgObjs))
+			adjustedSum += adjustedSeriesForType * (2 + avgObjs)
+		default:
+			if s.series > 0 {
+				log.Fatalf("not supported %v metric in avalanche", mtype)
 			}
 		}
-		fmt.Printf("--series-count=10\n")
-		fmt.Printf("--value-interval=300 # Changes values every 5m.\n")
-		fmt.Printf("--series-interval=3600 # 1h series churn.\n")
-		fmt.Printf("--metric-interval=0\n")
-
-		fmt.Println("This should give the total adjusted series to:", adjustedSum*10)
 	}
+	flags = append(flags, fmt.Sprintf("--series-count=10"))
+	// Changes values every 5m.
+	flags = append(flags, "--value-interval=300")
+	// 1h series churn.
+	flags = append(flags, "--series-interval=3600")
+	flags = append(flags, "--metric-interval=0")
+
+	return flags, adjustedSum
 }
 
 var allTypes = []dto.MetricType{dto.MetricType_GAUGE, dto.MetricType_COUNTER, dto.MetricType_HISTOGRAM, metricType_NATIVE_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM, dto.MetricType_SUMMARY, dto.MetricType_UNTYPED}

--- a/cmd/mtypes/main_test.go
+++ b/cmd/mtypes/main_test.go
@@ -1100,6 +1100,7 @@ func TestComputeAvalancheFlags(t *testing.T) {
 	for _, tc := range []struct {
 		testName               string
 		avalancheFlagsForTotal int
+		seriesCount            int
 		statistics             map[dto.MetricType]stats
 		total                  stats
 		expectedSum            int
@@ -1108,6 +1109,7 @@ func TestComputeAvalancheFlags(t *testing.T) {
 		{
 			testName:               "samplePromInput",
 			avalancheFlagsForTotal: 1000,
+			seriesCount:            10,
 			statistics: map[dto.MetricType]stats{
 				dto.MetricType_COUNTER:   {families: 104, series: 166, adjustedSeries: 166},
 				dto.MetricType_GAUGE:     {families: 77, series: 94, adjustedSeries: 94},
@@ -1135,14 +1137,25 @@ func TestComputeAvalancheFlags(t *testing.T) {
 		{
 			testName:               "noInput",
 			avalancheFlagsForTotal: 1000,
+			seriesCount:            10,
 			statistics:             map[dto.MetricType]stats{},
 			total:                  stats{},
-			expectedSum:            84,
-			expectedFlags:          []string{},
+			expectedSum:            0,
+			expectedFlags: []string{
+				"--gauge-metric-count=0",
+				"--counter-metric-count=0",
+				"--histogram-metric-count=0",
+				"--native-histogram-metric-count=0",
+				"--summary-metric-count=0",
+				"--series-count=10",
+				"--value-interval=300",
+				"--series-interval=3600",
+				"--metric-interval=0",
+			},
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			avalancheFlags, adjustedSum := computeAvalancheFlags(tc.avalancheFlagsForTotal, tc.total, tc.statistics)
+			avalancheFlags, adjustedSum := computeAvalancheFlags(tc.avalancheFlagsForTotal, tc.seriesCount, tc.total, tc.statistics)
 			assert.Equal(t, tc.expectedSum, adjustedSum)
 			assert.Equal(t, tc.expectedFlags, avalancheFlags)
 		})

--- a/cmd/mtypes/main_test.go
+++ b/cmd/mtypes/main_test.go
@@ -1132,6 +1132,14 @@ func TestComputeAvalancheFlags(t *testing.T) {
 				"--metric-interval=0",
 			},
 		},
+		{
+			testName:               "noInput",
+			avalancheFlagsForTotal: 1000,
+			statistics:             map[dto.MetricType]stats{},
+			total:                  stats{},
+			expectedSum:            84,
+			expectedFlags:          []string{},
+		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			avalancheFlags, adjustedSum := computeAvalancheFlags(tc.avalancheFlagsForTotal, tc.total, tc.statistics)


### PR DESCRIPTION
Fix a zero-divide crash in `mtypes` if the input lacks either summary metrics or histogram metrics.

In the process, add test cover for the `-avalanche-flags-for-adjusted-series` flag, and expand the other mtypes tests a bit.

Fixes https://github.com/prometheus-community/avalanche/issues/136