### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,58 +1,33 @@
 ---
+# Prometheus has switched to GitHub action.
+# Circle CI is not disabled repository-wise so that previous pull requests
+# continue working.
+# This file does not generate any CircleCI workflow.
+
 version: 2.1
 
-orbs:
-  prometheus: prometheus/prometheus@0.17.1
-
 executors:
-  # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:
     docker:
-      - image: quay.io/prometheus/golang-builder:1.22-base
+      - image: busybox
 
 jobs:
-  test:
+  noopjob:
     executor: golang
 
     steps:
-      - prometheus/setup_environment
-      - run: make
-      - prometheus/store_artifact:
-          file: avalanche
-      - run: git diff --exit-code
+      - run:
+          command: "true"
 
 workflows:
   version: 2
   avalanche:
     jobs:
-      - test:
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/build:
-          name: build
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/publish_main:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
+      - noopjob
+    triggers:
+      - schedule:
+          cron: "0 0 30 2 *"
           filters:
             branches:
-              only: main
-      - prometheus/publish_release:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
-          filters:
-            tags:
-              only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-            branches:
-              ignore: /.*/
+              only:
+                - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+---
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test_go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    container:
+      # Whenever the Go version is updated here, .promu.yml
+      # should also be updated.
+      image: quay.io/prometheus/golang-builder:1.26-base
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+      - run: make
+      - run: git diff --exit-code
+
+  build:
+    name: Build avalanche
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2, 3 ]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci/build@769ee18070cd21cfc2a24fa912349fd3e48dee58 # v0.6.0
+        with:
+          parallelism: 4
+          thread: ${{ matrix.thread }}
+
+  publish_main:
+    # https://github.com/prometheus/promci/blob/52c7012f5f0070d7281b8db4a119e21341d43c91/actions/publish_main/action.yml
+    name: Publish main branch artifacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci/publish_main@769ee18070cd21cfc2a24fa912349fd3e48dee58 # v0.6.0
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+
+  publish_release:
+    name: Publish release artefacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci/publish_release@769ee18070cd21cfc2a24fa912349fd3e48dee58 # v0.6.0
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here,
     # .circle/config.yml should also be updated.
-    version: 1.22
+    version: 1.26
 repository:
     path: github.com/prometheus-community/avalanche
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/prometheus-community/avalanche
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Migrate CI to GitHub Actions.
* Bump minimum Go version to 1.25.0.
* Update Go to 1.26.x.